### PR TITLE
Ignoring errors for the creation of admin. users for the pulibrary.dspace Role

### DIFF
--- a/ansible/roles/pulibrary.dspace/tasks/main.yml
+++ b/ansible/roles/pulibrary.dspace/tasks/main.yml
@@ -94,3 +94,4 @@
     - dspace_create_admin.rc == 0
   failed_when:
     - dspace_create_admin.rc == 1
+  ignore_errors: true


### PR DESCRIPTION
Ignoring errors for the creation of admin. users for DSpace over the CLI (there is not a way to test for this, and this fails intermittently in my local environment)